### PR TITLE
Add new player and support https

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,45 @@ or
 
 This will embed the video from http://www.bilibili.com/video/av2440534/.
 
-### Customizable video size?
+### More parameters
 
-Yes, from version 0.4.0, you can specify video size with format *`${video} @ ${width} x ${height}`*, for example
+Full parameters' format *`${video} @ ${section} @ ${width} x ${height} @ ${mode}`*
+
+#### Patameters description
+
+**video**
+
+video is bilibili video's number.
+
+**section**
+
+Indicates which sub video in the specified av number should be played.
+
+section counts from 1.
+
+**width x height**
+
+Specify the size of the player.
+
+Supported from version 0.4.0
+
+**mode**
+
+Specifies the player's mode, supports both flash and html5 modes.
+
+Supported from version 0.4.2
+
+#### Example
+
+Here are some examples.
 
 ```
 
-{% bilibili %} av2440534@640x480 {% endbilibili %}
+{% bilibili %} av2440534@1@640x480@html5 {% endbilibili %}
+
+{% bilibili %} 4950805@2@544x415@flash {% endbilibili %}
 
 ```
 
-will have video size 640 x 480.
-
-Have fun with gitbook and bilibili.
+> If you chose using full parameters mode, you should type all of parameters and don't omit any parameters.
+> Until now, flash player counldn't work correctly. I suggest that you should use html5 player.

--- a/index.js
+++ b/index.js
@@ -19,25 +19,45 @@ module.exports = {
             process: function (block) {
                 var replaced = block.body.replace('av', '').trim();
                 var video = replaced;
+                var mode = 'html5';
                 var width = 544;
                 var height = 415;
+
+                var section = 1;
+
+                var wrongParameter = false;
+
                 if (replaced.indexOf('@') > 0) {
                     var pair = replaced.split('@');
                     video = pair[0].trim();
-                    var size = pair[1].split('x');
+                    section = pair[1].trim();
+
+                    var size = pair[2].split('x');
                     width = size[0].trim();
                     height = size[1].trim();
+
+                    mode = pair[3].trim();
+                    if (mode != 'flash' && mode != 'html5') {
+                        wrongParameter = true;
+                    }
                 }
 
-                var url = "http://www.bilibili.com/video/av" + video + "/?br";
+                var url = "https://www.bilibili.com/video/av" + video + "/?br";
 
                 if (this.generator != "website") {
                     return '<p><a href="' + url + '">Video link</a></p>';
                 }
 
-                return '<div style="position: relative;padding-bottom: 56.25%;padding-top: 25px;height: 0;">'
-                    + '<embed height="' + height + '" width="' + width + '" quality="high" allowfullscreen="true" type="application/x-shockwave-flash" src="http://static.hdslb.com/miniloader.swf" flashvars="page=1&aid='+video+'" pluginspage="http://www.adobe.com/shockwave/download/download.cgi?P1_Prod_Version=ShockwaveFlash"></embed>'
-                    + '</div>';
+                var result = '<div style="position: relative;padding-bottom: 56.25%;padding-top: 25px;height: 0;">'
+                if (!wrongParameter) {
+                    if (mode == 'flash') {
+                        result = result + '<embed height="' + height + '" width="' + width + '" quality="high" allowfullscreen="true" type="application/x-shockwave-flash" src="https://static.hdslb.com/miniloader.swf" flashvars="page=' + section + '&aid=' + video + '" pluginspage="http://www.adobe.com/shockwave/download/download.cgi?P1_Prod_Version=ShockwaveFlash"></embed>'
+                    } else {
+                        result = result + '<iframe height="' + height + '" width="' + width + '" src="https://player.bilibili.com/player.html?aid=' + video + '&page=' + section + '" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true"> </iframe>'
+                    }
+                }
+                result = result + '</div>';
+                return result;
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "gitbook-plugin-bilibili",
     "description": "Bilibili video integration with video id",
     "main": "index.js",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "engines": {
         "gitbook": ">1.x.x"
     },


### PR DESCRIPTION
Here are what I have done.
- Make all of resources to be https resources
- Add Html5 player for this plugin
- Support section
- Change default settings

I notice that your flash player don't work correctly. So I never change your code related to flash player.

Because of flash player's error, I let the default player be an HTML5 player. Html5 player is nice for Linux user.

I make all of resources to be https resources. Because almost **Page** websites support Https and if you load a http resource in that website, the website will throw a warning message. It's so ugly. So I change it.

I change some patameter's structure. pls notice it.

I'm not familiar with Apache License. If I do something wrong, pls tell me.